### PR TITLE
Fix for Firefox

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -261,7 +261,7 @@
         if (this.errors.length > 0) {
             if (evt && evt.preventDefault) {
                 evt.preventDefault();
-            } else if (event) {
+            } else if (typeof event === 'object') {
                 // IE uses the global event variable
                 event.returnValue = false;
             }


### PR DESCRIPTION
Validate.js crashes in Firefox with `ReferenceError: event is not defined`